### PR TITLE
chore(deps): certifi (2023.5.7 -> 2023.7.22)

### DIFF
--- a/.changeset/dirty-kings-hammer.md
+++ b/.changeset/dirty-kings-hammer.md
@@ -1,0 +1,5 @@
+---
+'json-on-the-clocktower': patch
+---
+
+chore(deps): certifi (2023.5.7 -> 2023.7.22)

--- a/poetry.lock
+++ b/poetry.lock
@@ -66,13 +66,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]


### PR DESCRIPTION
manual poetry update for https://github.com/chizmw/json-on-the-clocktower/security/dependabot/1